### PR TITLE
Updated IOC for VirusTool Tool to support all the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,96 @@ Action:
 
 ````
 
-More to come!
+Other Use Cases: Domain, URL, File
+
+## Domain
+
+````
+response = agent("Is this domain example.com malicious according to Virus Total?")
+
+Thought:The IP address 1.2.3.4 is classified as a legitimate IP that doesn't serve any malicious purpose according to the VirusTotal report. It has a reputation score of -11 and is associated with various harmless results from different engines. The analysis indicates that it is not considered malicious.
+
+Action:
+```
+{
+  "action": "Final Answer",
+  "action_input": "The IP address 1.2.3.4 is not malicious according to VirusTotal."
+}
+```
+
+
+> Finished chain.
+{'input': 'is the IP 1.2.3.4 malicious according to Virus Total ?', 'chat_history': [], 'output': 'The IP address 1.2.3.4 is not malicious according to VirusTotal.'}
+
+````
+
+## URL
+
+
+````
+response = agent("Is the File dc476ae39effdd80399b6e36f1fde92c216a5bbdb6b8b2a7ecbe753e91e4c993 malicious according to VirusTotal ?")
+
+Thought:The file with the hash dc476ae39effdd80399b6e36f1fde92c216a5bbdb6b8b2a7ecbe753e91e4c993 is considered malicious according to VirusTotal analysis. It has been detected by multiple engines as malicious, categorized as a joke or time-related malware. The file is named traveler.exe and is associated with the ASPack packer and Borland Delphi compiler. It is advised to handle this file with caution.
+
+Action:
+```
+{
+  "action": "Final Answer",
+  "action_input": "The file dc476ae39effdd80399b6e36f1fde92c216a5bbdb6b8b2a7ecbe753e91e4c993 is considered malicious according to VirusTotal analysis. It is categorized as a trojan.joke/changetime."
+}
+```
+
+
+> Finished chain.
+{'input': 'Is the File dc476ae39effdd80399b6e36f1fde92c216a5bbdb6b8b2a7ecbe753e91e4c993 malicious according to VirusTotal ?', 'chat_history': [], 'output': 'The file dc476ae39effdd80399b6e36f1fde92c216a5bbdb6b8b2a7ecbe753e91e4c993 is considered malicious according to VirusTotal analysis. It is categorized as a trojan.joke/changetime.'}
+
+
+````
+
+## URL
+
+
+````
+response = agent("Is the url "{http://117.248.172.130:50994/bin.sh}" malicious according to VirusTotal ?")
+
+Thought:The URL "{http://117.248.172.130:50994/bin.sh}" has been identified as malicious by several engines, including Sophos and Webroot, categorizing it as malware. The analysis indicates that it is associated with the Mozi botnet, known for infecting systems through brute-forcing SSH and Telnet ports. It is recommended to avoid accessing this URL to prevent potential security risks.
+
+Thought: I have the information needed to provide a final response to the user's query.
+
+Action:
+```
+{
+  "action": "Final Answer",
+  "action_input": "The URL http://117.248.172.130:50994/bin.sh is considered malicious according to VirusTotal analysis."
+}
+```
+
+> Finished chain.
+{'input': 'Is the url http://117.248.172.130:50994/bin.sh malicious according to VirusTotal ?', 'chat_history': [], 'output': 'The URL http://117.248.172.130:50994/bin.sh is considered malicious according to VirusTotal analysis.'}
+
+
+````
+
+## Attack Technique
+
+
+````
+response = agent("Provide me details about the attack technique T1567 ?")
+
+Thought: I have retrieved detailed information about the attack technique T1567, which involves exfiltration over a web service. The technique description includes the use of legitimate external web services for data exfiltration, providing cover due to pre-existing network communication with these services. Additionally, adversaries may leverage SSL/TLS encryption for added protection.
+
+Action:
+```
+{
+  "action": "Final Answer",
+  "action_input": "The attack technique T1567 involves exfiltration over a web service, where adversaries may use legitimate external web services for data exfiltration, leveraging SSL/TLS encryption for added protection."
+}
+``` 
+
+
+
+> Finished chain.
+{'input': 'Provide me details about the attack technique T1567 ?', 'chat_history': [], 'output': 'The attack technique T1567 involves exfiltration over a web service, where adversaries may use legitimate external web services for data exfiltration, leveraging SSL/TLS encryption for added protection.'}
+
+
+````

--- a/cybertools/virustotal.py
+++ b/cybertools/virustotal.py
@@ -11,6 +11,7 @@ __status__ = "Development"
 
 from typing import Any, Dict, Optional
 
+import base64
 import aiohttp
 import requests
 from langchain_core.callbacks import (
@@ -23,15 +24,30 @@ from langchain_core.pydantic_v1 import BaseModel, root_validator
 from langchain_core.utils import get_from_dict_or_env
 import datetime
 
+
 class VirusTotalReportTool(BaseTool):
     """Tool that queries IOC reports from the VirusTotal API"""
 
     name: str = "virustotalapi"
     description: str = (
         "Threat intelligence API provided by virustotal.com"
-        "This tool is handy when you need to get reports from indicators of compromise (aka IOC) such as an ip address, a file hash or a domain."
+        "This tool is handy when you need to get reports from indicators of compromise (aka IOC) such as an ip address, a file hash, url, or a domain."
         "To use the tool, you must provide at least two of the following parameters "
         "['ioc_value','ioc_type']."
+
+        " Supports the following IOC types:"
+        " 'ipv4address': IP Address (e.g., '1.2.3.4'),'domain': Domain Name (e.g., 'example.com'),'filehash': File Hash (e.g., 'd41d8cd98f00b204e9800998ecf8427e')"
+        " 'url': URL ( e.g., 'https://www.priam.ai/blogs/virtual-soc')"
+        " 'analysis_id': Analysis ID (e.g., 'd41d8cd98f00b204e9800998ecf8427e')"
+        "'threat_categories': Popular Threat Categories"
+        " 'attack_tactic': Attack Tactic ID (e.g., 'TA0043')"
+        " 'attack_technique': Attack Technique ID (e.g., 'T1548')"
+        " 'comments': Comments (e.g., 'malware')"
+        "'behavior': Behavior Summary of a File (e.g., 'd41d8cd98f00b204e9800998ecf8427e') " 
+
+        "If a file hash has been given and the behaviour details are asked, then ioc type needs to be behavior "
+        "If there is any mention of comments the ioc_type needs be comments " 
+        "The IOC value for popular threat categories is none "    
         "For example to get a report about the IP address 1.2.3.4 the parameters are: ['1.2.3.4','ipv4address']"
     )
 
@@ -64,70 +80,80 @@ class VirusTotalReportTool(BaseTool):
         return results
 
     def _prepare_request(self, ioc_value: str,ioc_type:str=None,**kwargs: Any) -> dict:
+        """Prepare the request details for each of the VirusTotal API Endpoints based on IOC type and value."""
 
-        if ioc_type == "ipv4address":
+        ioc_type_mapping = {
+            "ipv4address": f"ip_addresses/{ioc_value}",
+            "domain": f"domains/{ioc_value}",
+            "filehash": f"files/{ioc_value}",
+            "url": f"urls/{base64.urlsafe_b64encode(ioc_value.encode()).decode().strip('=')}",
+            "analysis_id": f"analyses/{ioc_value}",
+            "threat_categories": "popular_threat_categories",
+            "attack_tactic": f"attack_tactics/{ioc_value}",
+            "attack_technique": f"attack_techniques/{ioc_value}",
+            "comments": f"comments?filter=tag%3A{ioc_value}&limit=1",
+            "behavior": f"files/{ioc_value}/behaviour_summary",
+    }
 
-            url = f"{self.base_url}/ip_addresses/{ioc_value}"
-
-            info = {
-            "url": url,
-            "headers": {
-                "x-apikey": f"{self.virustotal_api_key}",
-            },
-            "params": {
-                **{key: value for key, value in kwargs.items() if value is not None},
-                },
-            }
-            return info
-
-        elif ioc_type == "domain":
-            url = f"{self.base_url}/domains/{ioc_value}"
-
-            info = {
-            "url": url,
-            "headers": {
-                "x-apikey": f"{self.virustotal_api_key}",
-            },
-            "params": {
-                **{key: value for key, value in kwargs.items() if value is not None},
-                },
-            }
-            return info
-        else:
+        if ioc_type not in ioc_type_mapping:
             return {}
 
+        """ Based on the ioc type select from the dic and create the url """
+        url = f"{self.base_url}/{ioc_type_mapping[ioc_type]}"
+
+        info = {
+        "url": url,
+        "headers": {
+            "x-apikey": f"{self.virustotal_api_key}",
+        },           
+        "params": {
+            **{key: value for key, value in kwargs.items() if value is not None},
+            },
+        }
+        return info
+        
     def _search_api_results(self, ioc_value:str,ioc_type:str, **kwargs: Any) -> dict:
         request_details = self._prepare_request(ioc_value,ioc_type, **kwargs)
-        response = requests.get(
-            url=request_details["url"],
-            params=request_details["params"],
-            headers=request_details["headers"],
-        )
-        response.raise_for_status()
-        return response.json()
-
+        try:
+            response = requests.get(
+                url=request_details["url"],
+                params=request_details["params"],
+                headers=request_details["headers"],
+            )
+            response.raise_for_status()
+            return response.json()
+        
+        except requests.exceptions.HTTPError as http_err:
+            print(f"Error: The IOC value might be incorrect or not found. HTTP Error: {http_err}")
+            return {"error": "Incorrect IOC value or not found"}
+        
     async def _async_search_api_results(self, query: str, **kwargs: Any) -> dict:
         """Use aiohttp to send request to SearchApi API and return results async."""
         request_details = self._prepare_request(query, **kwargs)
-        if not self.aiosession:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(
+        try:
+            if not self.aiosession:
+                async with aiohttp.ClientSession() as session:
+                    async with session.get(
+                        url=request_details["url"],
+                        headers=request_details["headers"],
+                        params=request_details["params"],
+                        raise_for_status=True,
+                    ) as response:
+                        results = await response.json()
+            else:
+                async with self.aiosession.get(
                     url=request_details["url"],
                     headers=request_details["headers"],
                     params=request_details["params"],
                     raise_for_status=True,
                 ) as response:
                     results = await response.json()
-        else:
-            async with self.aiosession.get(
-                url=request_details["url"],
-                headers=request_details["headers"],
-                params=request_details["params"],
-                raise_for_status=True,
-            ) as response:
-                results = await response.json()
-        return results
-
+            return results
+        
+        except aiohttp.ClientResponseError as http_err:
+            print(f"Error: The IOC value might be incorrect or not found. HTTP Error: {http_err}")
+            return {"error": "Incorrect IOC value or not found"}
+        
     @staticmethod
     def _result_as_string(result: dict, root_key:None) -> str:
         '''

--- a/examples/run_qa.py
+++ b/examples/run_qa.py
@@ -56,7 +56,7 @@ new_prompt = agent.agent.create_prompt(
 agent.agent.llm_chain.prompt = new_prompt
 agent.tools = tools
 
-response = agent("Is this IP 1.2.3.4 malicious according to Virus Total?")
+response = agent(input("How may I assist you?\n"))
 
 print(response)
 


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the VirusTotalReportTool(), expanding its capabilities for querying IOC reports from the VirusTotal API. 

1. Added support for the following IOC types - GET Request.
   - File hash
   - url
   - Analysis id
   - Threat categories
   - Attack tactic
   - Attack technique
   - Comments
   - File Behavior

2. Updated the tool's description to provide the agent with better understanding of which IOC type to select by providing usage examples.

3. Implemented basic error handling for HTTP and request-related exceptions in '_search_api_results' and '_async_search_api_results' and added user-friendly error messages for incorrect or not found IOC values.

4. Improved _prepare_request method to dynamically generate the request URL based on the IOC type.